### PR TITLE
Oauth, redirect for ios/android

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -14,6 +14,7 @@ module.file_ext=.scss
 module.name_mapper='^assets' ->'<PROJECT_ROOT>/source/assets'
 module.name_mapper='^components' ->'<PROJECT_ROOT>/source/components'
 module.name_mapper='^scenes' ->'<PROJECT_ROOT>/source/scenes'
+module.name_mapper='^services' ->'<PROJECT_ROOT>/source/services'
 module.name_mapper='^styles' ->'<PROJECT_ROOT>/source/styles'
 module.name_mapper.extension='scss' -> 'empty/object'
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   printWidth: 100,
   singleQuote: true,
-  trailingComma: "es5"
+  trailingComma: "all"
 }

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,4 +1,5 @@
 const merge = require('webpack-merge');
+const webpack = require('webpack');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
@@ -6,5 +7,19 @@ module.exports = merge(common, {
   devtool: 'inline-source-map',
   devServer: {
     historyApiFallback: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        pathRewrite: {
+          '^/api': '',
+        },
+      },
+    },
   },
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'development',
+      API_ENDPOINT: '/api',
+    }),
+  ],
 });

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -3,4 +3,10 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      NODE_ENV: 'production',
+      API_ENDPOINT: 'https://api.hackillinois.org',
+    }),
+  ],
 });

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,4 +1,5 @@
 const merge = require('webpack-merge');
+const webpack = require('webpack');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,14 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "requires": {
+        "regenerator-runtime": "0.12.1"
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.44",
       "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
@@ -2978,14 +2986,18 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -6148,6 +6160,11 @@
         "array-includes": "3.0.3"
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "killable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
@@ -8332,6 +8349,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "strict-uri-encode": "2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8471,6 +8497,40 @@
         "react": "16.4.2"
       }
     },
+    "react-is": {
+      "version": "16.6.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
+      "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-redux": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
+      "requires": {
+        "@babel/runtime": "7.1.5",
+        "hoist-non-react-statics": "3.2.0",
+        "invariant": "2.2.4",
+        "loose-envify": "1.4.0",
+        "prop-types": "15.6.2",
+        "react-is": "16.6.3",
+        "react-lifecycles-compat": "3.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz",
+          "integrity": "sha512-3IascCRfaEkbmHjJnUxWSspIUE1okLPjGTMVXW8zraUo1t3yg1BadKAxAGILHwgoBzmMnzrgeeaDGBvpuPz6dA==",
+          "requires": {
+            "react-is": "16.6.3"
+          }
+        }
+      }
+    },
     "react-router": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
@@ -8592,11 +8652,38 @@
         }
       }
     },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "1.4.0",
+        "symbol-observable": "1.2.0"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "0.3.8"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -9585,6 +9672,11 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -9693,8 +9785,7 @@
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,17 @@
   "homepage": "https://github.com/HackIllinois/site-2019#readme",
   "dependencies": {
     "animejs": "^2.2.0",
+    "jwt-decode": "^2.2.0",
     "prop-types": "^15.6.2",
+    "query-string": "^6.2.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-ga": "^2.5.3",
-    "react-router-dom": "^4.3.1"
+    "react-redux": "^5.1.1",
+    "react-router-dom": "^4.3.1",
+    "redux": "^4.0.1",
+    "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.1.2",

--- a/source/App.jsx
+++ b/source/App.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import ReactGA from 'react-ga';
 
+import Auth from 'scenes/Auth';
 import Error from 'scenes/Error';
 import Home from 'scenes/Home';
 import PDFView from 'scenes/PDFView';
@@ -19,6 +20,7 @@ const App = () => (
       <RouteTracker />
       <Switch>
         <Route exact path="/" component={Home} />
+        <Route exact path="/auth" component={Auth} />
         <Route exact path="/sponsor" component={PDFView('/assets/sponsorship-2019.pdf')} />
         <Route exact path="/mentor" component={PDFView('/assets/mentorship-2019.pdf')} />
         <Route component={() => <Error message="404 Not Found" />} />

--- a/source/index.jsx
+++ b/source/index.jsx
@@ -10,5 +10,5 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );

--- a/source/index.jsx
+++ b/source/index.jsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+import store from './services/store';
 
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('root')
+);

--- a/source/scenes/Auth/index.js
+++ b/source/scenes/Auth/index.js
@@ -1,0 +1,43 @@
+// @flow
+import queryString from 'query-string';
+import { connect } from 'react-redux';
+
+import { authCode } from 'services/auth/actions';
+
+import type { Location } from 'react-router-dom';
+
+type Props = {
+  location: Location,
+  authorize: string => void,
+  readToken: string => void,
+};
+
+type Params = {
+  code: string,
+  isAndroid: ?string,
+  isiOS: ?string,
+};
+
+const Auth = (props: Props) => {
+  const { location, authorize } = props;
+  const qs: Params = queryString.parse(location.search);
+  const { code, isAndroid, isiOS } = qs;
+
+  if (isAndroid) {
+    window.location.assign(`hackillinois://org.hackillinois.android/auth?code=${code}`);
+  } else if (isiOS) {
+    window.location.assign(`hackillinois://org.hackillinois.ios/auth?code=${code}`);
+  } else {
+    authorize(code);
+  }
+  return null;
+};
+
+const mapDispatchToProps = dispatch => ({
+  authorize: code => dispatch(authCode(code)),
+});
+
+export default connect(
+  undefined,
+  mapDispatchToProps
+)(Auth);

--- a/source/scenes/Auth/index.js
+++ b/source/scenes/Auth/index.js
@@ -39,5 +39,5 @@ const mapDispatchToProps = dispatch => ({
 
 export default connect(
   undefined,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(Auth);

--- a/source/services/api/auth.js
+++ b/source/services/api/auth.js
@@ -1,0 +1,17 @@
+const authRoute = `${process.env.API_ENDPOINT}/auth`;
+
+export default function authenticateCode(code) {
+  return fetch(`${authRoute}/code/github/`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code }),
+  }).then(response => {
+    if (response.status >= 400) {
+      throw new Error(response);
+    }
+    return response.json();
+  });
+}

--- a/source/services/auth/actions.js
+++ b/source/services/auth/actions.js
@@ -1,0 +1,42 @@
+import authenticateCode from 'services/api/auth';
+
+import { readJWT } from '../user/actions';
+import { setError } from '../error/actions';
+
+export const AUTH_CODE_REQUEST = 'AUTH_CODE_REQUEST';
+export const AUTH_CODE_FAILURE = 'AUTH_CODE_FAILURE';
+export const AUTH_CODE_SUCCESS = 'AUTH_CODE_SUCCESS';
+
+function requestAuth() {
+  return {
+    type: AUTH_CODE_REQUEST,
+  };
+}
+
+function receiveAuth(err, data) {
+  if (err) {
+    return {
+      type: AUTH_CODE_FAILURE,
+      err,
+    };
+  }
+  return {
+    type: AUTH_CODE_SUCCESS,
+    jwt: data.token,
+  };
+}
+
+export function authCode(code) {
+  return dispatch => {
+    dispatch(requestAuth());
+    authenticateCode(code)
+      .then(data => {
+        dispatch(receiveAuth(null, data));
+        dispatch(readJWT(data.token));
+      })
+      .catch(err => {
+        dispatch(receiveAuth(err, null));
+        dispatch(setError('OAuth Error'));
+      });
+  };
+}

--- a/source/services/auth/reducer.js
+++ b/source/services/auth/reducer.js
@@ -1,0 +1,22 @@
+import { AUTH_CODE_REQUEST, AUTH_CODE_SUCCESS, AUTH_CODE_FAILURE } from './actions';
+
+const initialState = {
+  fetching: false,
+  error: null,
+  jwt: null,
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case AUTH_CODE_REQUEST:
+      return Object.assign({}, state, { fetching: true, error: null, jwt: null });
+    case AUTH_CODE_SUCCESS:
+      return Object.assign({}, state, { fetching: false, error: null, jwt: action.jwt });
+    case AUTH_CODE_FAILURE:
+      return Object.assign({}, state, { fetching: false, error: action.err, user: null });
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/source/services/error/actions.js
+++ b/source/services/error/actions.js
@@ -1,0 +1,9 @@
+// @flow
+export const SET_ERROR = 'SET_ERROR';
+
+export function setError(error: string) {
+  return {
+    type: SET_ERROR,
+    error,
+  };
+}

--- a/source/services/error/reducer.js
+++ b/source/services/error/reducer.js
@@ -1,0 +1,16 @@
+import { SET_ERROR } from './actions';
+
+const initialState = {
+  error: null,
+};
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_ERROR:
+      return Object.assign({}, state, { error: action.error });
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/source/services/store.js
+++ b/source/services/store.js
@@ -1,0 +1,17 @@
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import logger from 'redux-logger';
+import thunk from 'redux-thunk';
+
+import authReducer from './auth/reducer';
+import errorReducer from './error/reducer';
+import userReducer from './user/reducer';
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+  error: errorReducer,
+  user: userReducer,
+});
+
+const store = createStore(rootReducer, applyMiddleware(thunk, logger));
+
+export default store;

--- a/source/services/user/actions.js
+++ b/source/services/user/actions.js
@@ -1,0 +1,8 @@
+export const READ_JWT = 'READ_JWT';
+
+export function readJWT(jwt) {
+  return {
+    type: READ_JWT,
+    jwt,
+  };
+}

--- a/source/services/user/reducer.js
+++ b/source/services/user/reducer.js
@@ -1,0 +1,25 @@
+import jwtDecode from 'jwt-decode';
+
+import { READ_JWT } from './actions';
+
+const initialState = {
+  email: null,
+  id: null,
+  roles: [],
+};
+
+function readJWT(state, jwt) {
+  const { email, id, roles } = jwtDecode(jwt);
+  return Object.assign({}, state, { email, id, roles });
+}
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case READ_JWT:
+      return readJWT(state, action.jwt);
+    default:
+      return state;
+  }
+};
+
+export default reducer;


### PR DESCRIPTION
**Summary**
Added redux into app to support storing JWT/user information. `/auth` route set up to redirect based on platform (specified by query params). On web, JWT is retrieved from OAuth code and is decoded into Redux store.

**Test Plan**
Tested manually with hand crafted query params on `/auth` route. Used live API to generate JWT to test JWT decoding.

Unsure of how to test intents for iOS/Android